### PR TITLE
elasticsearch 2.x support

### DIFF
--- a/pom.xml.elasticsearch-2.0.0
+++ b/pom.xml.elasticsearch-2.0.0
@@ -1,0 +1,187 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.amazonaws</groupId>
+    <artifactId>cloudwatch-logs-subscription-consumer</artifactId>
+    <version>1.2.0</version>
+    <name>CloudWatch Logs Subscription Consumer</name>
+    <description>The CloudWatch Logs Subscription Consumer helps Java developers consume a real-time feed of CloudWatch Logs data for custom processing, analysis, or loading to other systems.</description>
+    <url>https://aws.amazon.com/cloudwatch</url>
+
+    <licenses>
+        <license>
+           <name>Amazon Software License</name>
+           <url>https://aws.amazon.com/asl</url>
+           <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <profiles>
+
+        <profile>
+            <id>Stdout</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+                <property>
+                    <name>connectorDestination</name>
+                    <value>stdout</value>
+                </property>
+            </activation>
+            <properties>
+                <connector.mainclass>com.amazonaws.services.logs.connectors.samples.stdout.StdoutConnector</connector.mainclass>
+            </properties>
+        </profile>
+
+        <profile>
+            <id>Elasticsearch</id>
+            <activation>
+                <property>
+                    <name>connectorDestination</name>
+                    <value>elasticsearch</value>
+                </property>
+            </activation>
+            <properties>
+                <connector.mainclass>com.amazonaws.services.logs.connectors.samples.elasticsearch.ElasticsearchConnector</connector.mainclass>
+            </properties>
+        </profile>
+
+        <profile>
+            <id>S3</id>
+            <activation>
+                <property>
+                    <name>connectorDestination</name>
+                    <value>s3</value>
+                </property>
+            </activation>
+            <properties>
+                <connector.mainclass>com.amazonaws.services.logs.connectors.samples.s3.S3Connector</connector.mainclass>
+            </properties>
+        </profile>
+
+    </profiles>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>amazon-kinesis-connectors</artifactId>
+            <version>LATEST</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.elasticsearch</groupId>
+            <artifactId>elasticsearch</artifactId>
+            <version>2.0.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
+            <version>2.6</version>
+        </dependency>
+        
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.4</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+            <version>1.2.17</version>
+        </dependency>
+    </dependencies>
+
+    <developers>
+        <developer>
+            <id>amazonwebservices</id>
+            <organization>Amazon Web Services</organization>
+            <organizationUrl>https://aws.amazon.com</organizationUrl>
+            <roles>
+                <role>developer</role>
+            </roles>
+        </developer>
+    </developers>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.2</version>
+                    <configuration>
+                        <source>1.7</source>
+                        <target>1.7</target>
+                        <encoding>UTF-8</encoding>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-gpg-plugin</artifactId>
+                <version>1.5</version>
+                <executions>
+                    <execution>
+                        <id>sign-artifacts</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>sign</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>1.2.1</version>
+                <configuration>
+                    <mainClass>${connector.mainclass}</mainClass>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>2.6</version>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <addClasspath>true</addClasspath>
+                            <classpathPrefix>lib/</classpathPrefix>
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>2.5.5</version>
+                <executions>
+                    <execution>
+                        <id>create-distribution</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <descriptors>
+                                <descriptor>assembly/cfn.xml</descriptor>
+                            </descriptors>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/src/main/java/com/amazonaws/services/logs/connectors/elasticsearch/CloudWatchLogsElasticsearch2Document.java
+++ b/src/main/java/com/amazonaws/services/logs/connectors/elasticsearch/CloudWatchLogsElasticsearch2Document.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Amazon Software License (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://aws.amazon.com/asl/
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.services.logs.connectors.elasticsearch;
+
+import java.util.Map;
+
+import org.apache.commons.lang3.StringUtils;
+
+import com.amazonaws.services.logs.subscriptions.CloudWatchLogsEvent;
+import com.amazonaws.util.json.JSONException;
+import com.amazonaws.util.json.JSONObject;
+
+/**
+ * Defines the log event structure that would be sent to Elasticsearch.
+ */
+public class CloudWatchLogsElasticsearchDocument {
+
+    private static final String JSON_FIELD_NAME_PREFIX = "$";
+
+    private final String id;
+    private final long timestamp;
+    private final String message;
+
+    private final String owner;
+    private final String logGroup;
+    private final String logStream;
+
+    private final String source;
+
+    public CloudWatchLogsElasticsearchDocument(CloudWatchLogsEvent event) throws JSONException {
+        JSONObject json = getFields(event.getMessage(), event.getExtractedFields());
+        json.put("@id", event.getId());
+        json.put("@timestamp", event.getTimestamp());
+        json.put("@message", event.getMessage());
+        json.put("@owner", event.getOwner());
+        json.put("@log_group", event.getLogGroup());
+        json.put("@log_stream", event.getLogStream());
+
+        this.source = json.toString();
+
+        this.id = event.getId();
+        this.timestamp = event.getTimestamp();
+        this.message = event.getMessage();
+        this.owner = event.getOwner();
+        this.logGroup = event.getLogGroup();
+        this.logStream = event.getLogStream();
+    }
+
+    /**
+     * Determines which additional fields get put into the Elasticsearch document.
+     */
+    private JSONObject getFields(String message, Map<String, String> extractedFields) throws JSONException {
+
+        // if extractedFields are available from CloudWatch Logs, use them as Elasticsearch fields
+        if (extractedFields != null && extractedFields.size() > 0) {
+            JSONObject extractedFieldsInJson = new JSONObject();
+
+            for (Map.Entry<String, String> entry : extractedFields.entrySet()) {
+                String fieldName = entry.getKey();
+                String value = entry.getValue();
+
+                if (value == null) {
+                    // nothing to add
+                    continue;
+                }
+
+                if (StringUtils.isNumeric(value)) {
+                    // the field value is a number - put it as a double
+                    extractedFieldsInJson.put(fieldName, Double.parseDouble(value));
+                    continue;
+                }
+
+                String jsonSubString = ElasticsearchTransformerUtils.extractJson(value);
+
+                if (jsonSubString != null) {
+                    // the field value contains valid json - copy the json to a new Elasticsearch object field
+                    extractedFieldsInJson.put(JSON_FIELD_NAME_PREFIX + fieldName, new JSONObject(jsonSubString));
+                }
+
+                // put the raw extracted field as a string
+                extractedFieldsInJson.put(fieldName, value);
+            }
+
+            return extractedFieldsInJson;
+        }
+
+        // if the message is valid JSON, use the message as is for Elasticsearch fields
+        if (ElasticsearchTransformerUtils.extractJson(message) != null) {
+            return new JSONObject(message);
+        }
+
+        // if there are no extractedFields and the message is not valid JSON, don't emit any Elasticsearch fields
+        return new JSONObject();
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public long getTimestamp() {
+        return timestamp;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public String getOwner() {
+        return owner;
+    }
+
+    public String getLogGroup() {
+        return logGroup;
+    }
+
+    public String getLogStream() {
+        return logStream;
+    }
+
+    public String getSource() {
+        return source;
+    }
+}


### PR DESCRIPTION
## Purpose

Currently there is no elasticsearch 2.x.x support in the `cloudwatch-logs-subscription-consumer` library. This PR is a first step forward towards getting support implemented.
### Status

**DEPENDS ON: https://github.com/awslabs/amazon-kinesis-connectors/pull/63**
WORK IN PROGRESS / NEED HELP
### Related Issues and PRs
- [Upgrade to a newer Elasticsearch version ?](https://github.com/awslabs/amazon-kinesis-connectors/issues/52)
- [Errors using consumer with ES 2.0](https://github.com/awslabs/cloudwatch-logs-subscription-consumer/issues/8)
- https://github.com/awslabs/amazon-kinesis-connectors/pull/63
### Background

I was enticed to use the [cloudwatch-logs-subscription-consumer](https://github.com/awslabs/cloudwatch-logs-subscription-consumer) by @DVassallo one day and went about trying to get it to work with our already implemented elasticsearch 2.0.0 installation in AWS. By figuring out what had changed between the 1.x and 2.x versions of elasticsearch ([great reference here](https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking_20_java_api_changes.html)) I was then able to go through the `amazon-kinesis-connectors` code and the `cloudwatch-subscription-consumer` code and make some changes to support 2.x. I then built a local `.jar` for `amazon-kinesis-connectors` after making some `pom.xml` changes. Followed by changes to `cloudwatch-logs-subscription-consumer` that fixed `ImmutableSettings` and re-wrote the `ElasticsearchEmitter` function to use the [methods outlined in the java api doc here](https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking_20_java_api_changes.html).

I was then able to make a successful connection to elasticsearch and see records start coming through. There are still a few things to iron out, they are outlined below. But the hope is, people who really need it can start using the configs in the PR and then soon it will be merged and fully functional.
### ToDos
- [ ] This PR has to be merged in a useable way (meaning it detects the version of elasticsearch and adapts accordingly) before the changes I've made can be merged in a non-hacky way. https://github.com/awslabs/amazon-kinesis-connectors/pull/63
- [ ] Add some more documentation.
### Other Notes
- This was tested in Centos 6.7 and nowhere else.
- The amazon-kinesis-connectors library was built locally using Maven, and then very hackily the .jar was copied over the local library .jar and then built against, this is not recommended unless you know what you're doing, which I really didn't until I did it :).
